### PR TITLE
Correct GitHub terminology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The `main` branch of this repo contains the raw source of the site and should be
 
 During development, you can generate a preview of the site with `npm run watch`. To view the output, open `_dist/index.html` in your web browser.
 
-Any time `main` is updated via merge request, CI will rebuild the site and push updates to the `gh-pages` branch, which will then be served by GitHub Pages.
+Any time `main` is updated via pull request, CI will rebuild the site and push updates to the `gh-pages` branch, which will then be served by GitHub Pages.


### PR DESCRIPTION
The README says "merge request" because I spend too much time in GitLab.